### PR TITLE
Set fixed size for Google Chrome when open up a new instance

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ def pytest_addoption(parser):
 @pytest.fixture
 def old_driver(request):
     chrome_options = webdriver.ChromeOptions()
+    chrome_options.add_argument("--window-size=1024,768")
     headless = request.config.getoption("--headless") == "True"
     if headless:
         chrome_options.add_argument("--headless")


### PR DESCRIPTION
## Description
When launching a new browser instance, we need to set a fixed size so later on, we can capture actual images and compare them with the expected outcomes (as plugin funtionality)

## Related Issue
N/A

## Motivation and Context
N/A

## How Has This Been Tested?
Tested locally with browser UI (none headless)
![image](https://user-images.githubusercontent.com/112688094/211268311-1865a77b-c48d-4350-81b0-b472cea3a416.png)
