### PR TITLE
fix bug when casting to boolean

### DIFF
--- a/src/enhanced_reports/config.py
+++ b/src/enhanced_reports/config.py
@@ -151,8 +151,10 @@ def _get_value(request: FixtureRequest, parameter: Parameter):
 
     # Cast the value to the specified type, if needed
     if "cast_to" in __params[parameter]:
-        value = __params[parameter]["cast_to"](value)
-
+        if __params[parameter]["cast_to"] == bool:
+            return value in ["True", "true", "TRUE"]
+        else:
+            value = __params[parameter]["cast_to"](value)
     return value
 
 


### PR DESCRIPTION
when casting to bool, since the input value is in STRING format, this value is ALWAYS TRUE
e.g: bool('False') => True